### PR TITLE
fix: replace `-q` flag in `grep` with `>/dev/null`, fixes #9

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -4,7 +4,7 @@ pre_install_actions:
   - |
     #ddev-nodisplay
     #ddev-description:Check for backdrop project type
-    if ! ddev debug configyaml | grep -q "^type:.*backdrop"; then
+    if ! ddev debug configyaml | grep "^type:.*backdrop" >/dev/null; then
       echo "This add-on is only available for projects with backdrop type"
       exit 2
     fi


### PR DESCRIPTION
## The Issue

- #9

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

I'm not sure why, but this should help with error.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/stasforks/ddev-backdrop-bee/tarball/20250422_stasadev_grep
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
